### PR TITLE
Add a render prop

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -60,6 +60,16 @@ class App extends Component {
           <button type='button' data-toggle>Toggle</button>
           <button type='button' data-clear>Clear</button>
         </Flatpickr>
+        <Flatpickr
+          defaultValue='2019-05-05'
+          render={({ defaultValue }, ref)=>{
+            return (
+              <div>
+                <label>DateTimePicker</label>
+                <input defaultValue={ defaultValue } ref={ref} />
+              </div>
+            )
+          }} />
       </main>
     )
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ class DateTimePicker extends Component {
       PropTypes.number
     ]),
     children: PropTypes.node,
-    className: PropTypes.string
+    className: PropTypes.string,
+    render: PropTypes.func
   }
 
   static defaultProps = {
@@ -107,22 +108,24 @@ class DateTimePicker extends Component {
 
   render() {
     // eslint-disable-next-line no-unused-vars
-    const { options, defaultValue, value, children, ...props } = this.props
+    const { options, defaultValue, value, children, render, ...props } = this.props
+    const ref = (node) => { this.node = node }
 
     // Don't pass hooks to dom node
     hooks.forEach(hook => {
       delete props[hook]
     })
 
+    if (render) return render({ ...props, defaultValue, value }, ref)
+
     return options.wrap
       ? (
-        <div {...props} ref={node => { this.node = node }}>
+        <div {...props} ref={ref}>
           { children }
         </div>
       )
       : (
-        <input {...props} defaultValue={defaultValue}
-          ref={node => { this.node = node }} />
+        <input {...props} defaultValue={defaultValue} ref={ref} />
       )
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,8 +10,8 @@ describe("react-flatpickr", () => {
     component.unmount()
   })
 
-  describe("when a value is provided", () => {
-    describe("and it is in the YYYY-MM-DD format", () => {
+  describe("#value", () => {
+    describe("is in the YYYY-MM-DD format", () => {
       it("shows it in the input", () => {
         const component = mount(<DateTimePicker value="2000-01-01" />)
         const input = component.find("input").instance()
@@ -20,13 +20,41 @@ describe("react-flatpickr", () => {
       })
     })
 
-    describe("and it is in the YYYY.MM.DD format", () => {
+    describe("is in the YYYY.MM.DD format", () => {
       it("normalizes it and shows in the input", () => {
         const component = mount(<DateTimePicker value="2000.01.01" />)
         const input = component.find("input").instance()
         expect(input.value).toBe("2000-01-01")
         component.unmount()
       })
+    })
+  })
+
+  describe("#render", () => {
+    it("is possible to provide a custom input", () => {
+      function MaskedInput ({ defaultValue, innerRef }) {
+        return (<input defaultValue={defaultValue} ref={innerRef} />)
+      }
+      const component = mount(
+        <DateTimePicker
+          defaultValue="2000-01-01"
+          render={
+            ({ defaultValue }, ref) => {
+              return (
+                <div>
+                  <MaskedInput defaultValue={defaultValue} innerRef={ref} />
+                  <span>bar</span>
+                </div>
+              )
+            }
+          }
+        />
+      )
+      const input = component.find("input").instance()
+      const span = component.find("span")
+      expect(input.value).toEqual("2000-01-01")
+      expect(span).toBeDefined()
+      component.unmount()
     })
   })
 })


### PR DESCRIPTION
Hey!

I have a real life use case where we'd like to be able to provide a custom masked input to flatpickr. To make it work properly I have to forward the ref to the input masking library as well so that it can attach its own handlers. Unfortunately the existing wrap option does not seem to be flexible enough to support this use case (as far as I tried).

I've added an additional `render` prop that can be used to have more control over the rendering process.