### PR TITLE
calendar open on component render

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -37,6 +37,12 @@ class App extends Component {
           ]} />
         <Flatpickr data-enable-time defaultValue='2016-11-11 11:11'
           onChange={(_, str) => console.info(str)} />
+        <Flatpickr
+          data-enable-time
+          defaultValue='2016-11-11 11:11'
+          onChange={(_, str) => console.info(str)}
+          open={true}
+        />
         <Flatpickr data-enable-time value={v}
           onChange={(_, str) => console.info(str)} />
         <Flatpickr value={v} options={{minDate: '2016-11-01'}}

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,7 @@ class DateTimePicker extends Component {
       PropTypes.object,
       PropTypes.number
     ]),
+    open: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
     render: PropTypes.func
@@ -105,6 +106,10 @@ class DateTimePicker extends Component {
     })
 
     this.flatpickr = new Flatpickr(this.node, options)
+
+    if (this.props.open) {
+      this.flatpickr.open()
+    }
 
     if (this.props.hasOwnProperty('value')) {
       this.flatpickr.setDate(this.props.value, false)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -66,6 +66,17 @@ describe("react-flatpickr", () => {
       component.unmount()
     })
 
+    it("is rendered open", () => {
+      let calendar
+      const component = mount(<DateTimePicker onCreate={(flatpickr) => { calendar = flatpickr }} open={true} />)
+
+      calendar.open = jest.fn()
+
+      expect(component.props().open).toEqual(true)
+      expect(calendar.isOpen).toEqual(true)
+      component.unmount()
+    })
+
     it("is possible to reference the flatpickr instance", () => {
       let calendar
       const component = mount(


### PR DESCRIPTION
`react-flatpickr` has no good way to render the calendar in an opened state on component render. 
Added this functionality via a prop.

After: 

![Screen Shot 2019-05-28 at 10 10 58 AM](https://user-images.githubusercontent.com/2117322/58489761-866a3a00-8131-11e9-97e9-68309f971cdc.png)
