### PR TITLE
Update options before value on props change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,10 +54,6 @@ class DateTimePicker extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.hasOwnProperty('value') && this.props.value !== prevProps.value) {
-      this.flatpickr.setDate(this.props.value, false)
-    }
-
     const { options } = this.props
     const prevOptions = prevProps.options
 
@@ -86,6 +82,9 @@ class DateTimePicker extends Component {
       }
     }
 
+    if (this.props.hasOwnProperty('value') && this.props.value !== prevProps.value) {
+      this.flatpickr.setDate(this.props.value, false)
+    }
   }
 
   componentDidMount() {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -28,6 +28,17 @@ describe("react-flatpickr", () => {
         component.unmount()
       })
     })
+
+    describe("is updated with a minDate", () => {
+      it("updates the minDate first", () => {
+        const component = mount(<DateTimePicker value="2000-01-01" options={{ minDate: "2000-01-01" }} />)
+        const input = component.find("input").instance()
+        expect(input.value).toBe("2000-01-01")
+        component.setProps({ value: "1999-01-01", options: { minDate: '1999-01-01' }});
+        expect(input.value).toBe("1999-01-01")
+        component.unmount()
+      })
+    })
   })
 
   describe("#render", () => {


### PR DESCRIPTION
Updating the value before the options can lead to assigning a date that is not allowed as per the previous props.

For instance, when a `minDate` is set, and we update both the `value` and `minDate`, the `value` will first be passed to Flatpickr, and then the update `minDate`. In which case, if the `value` conflicts with the previous `minDate`, Flatpickr will reject the new date, and will receive the updated `minDate` afterwards.

This patch ensures that the options are set before the value. A testcase also demonstrates the bug.