### PR TITLE
fix: upd css-loader vulnerability package, fix webpack example, upd flatpickr to the latest version

### DIFF
--- a/example/webpack.js
+++ b/example/webpack.js
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   module: {
-    loaders: [{
+    rules: [{
       loader: 'babel-loader',
       exclude: /node_modules/,
       options: config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flatpickr",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "flatpickr for React",
   "main": "build/index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   "author": "haoxin",
   "license": "MIT",
   "dependencies": {
-    "flatpickr": "^4.5.7",
+    "flatpickr": "^4.6.2",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.0",
-    "css-loader": "^0.28.7",
+    "css-loader": "^3.6.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "eslint": "^4.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,7 +3949,7 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
-flatpickr@^4.5.7:
+flatpickr@^4.6.2:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
   integrity sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ==


### PR DESCRIPTION
This will fix a vulnerability in the package
Will update the version of FlatPickr to the latest
And fix the webpack example which was not working because of a wrong config rule.