### PR TITLE
Trigger change when component's values have been updated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ class DateTimePicker extends Component {
     }
 
     if (this.props.hasOwnProperty('value') && this.props.value !== prevProps.value) {
-      this.flatpickr.setDate(this.props.value, false)
+      this.flatpickr.setDate(this.props.value, true)
     }
   }
 


### PR DESCRIPTION
Trigger the on change event and update the component properly when is dependent on other instance.

For example, having two instances of the component, when one of them is defining the minDate for the other, will cause on an update of a prior month that the second instance won't be rendered the list of months correctly.