### PR TITLE
Update flatpickr dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flatpickr",
-  "version": "3.10.7",
+  "version": "3.10.8",
   "description": "flatpickr for React",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "haoxin",
   "license": "MIT",
   "dependencies": {
-    "flatpickr": "^4.6.2",
+    "flatpickr": "4.6.9",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4031,7 +4031,7 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flatpickr@^4.6.2:
+flatpickr@4.6.9:
   version "4.6.9"
   resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.9.tgz#9a13383e8a6814bda5d232eae3fcdccb97dc1499"
   integrity sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw==


### PR DESCRIPTION
minDate prop from flatpickr dependency was causing problems and it's fixed inside the library.

https://github.com/flatpickr/flatpickr/commit/479418a7a13d987d4a306f7efe3242c3d823c48a

it would be nice to upgrade the version of it and publish a newer version