### PR TITLE
Fixed usage example in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -61,7 +61,7 @@ class App extends Component {
       <Flatpickr
         data-enable-time
         value={date}
-        onChange={date => {
+        onChange={([date]) => {
           this.setState({ date });
         }}
       />


### PR DESCRIPTION
The onChange callback actually passes an array of selected dates, not a single one.
So to set the new state to the selected date, one has to only use the first element of the passed in value.

The current suggestion (desctructuring the parameter) is the one with the least changes, but may be difficult to understand for inexperienced users.
A more verbose but potentially more comprehensive way of writing this could be:
```
onChange={selectedDates => {
    this.setState({ date: selectedDates[0] });
}}
```