### PR TITLE
update readme header to allow correct linking from table of contents

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -149,7 +149,7 @@ The following `props` are provided in order to customize the `Flatpickr's functi
 
 > `function` | optional
 
-## Advanced
+## Advanced props
 
 ### render prop
 


### PR DESCRIPTION
Noticed one of the readme anchors was incorrect. Quick fix to resolve.