### PR TITLE
Support React 19 on peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vite": "^4.2.1"
   },
   "peerDependencies": {
-    "react": ">=16, <=18"
+    "react": ">=16, <=19"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
The library works well on React 19 but peer dependencies are restricted to React <= 18. This causes npm install to fail (without --legacy-peer-deps).