### PR TITLE
Do not include dependencies in build results

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -15,7 +15,11 @@ export default defineConfig({
     },
     outDir: 'build',
     rollupOptions: {
-      external: Object.keys(packageJSON.peerDependencies),
+      external: [
+        ...Object.keys(packageJSON.dependencies),
+        ...Object.keys(packageJSON.peerDependencies),
+        'react/jsx-runtime',
+      ],
     },
   },
 })


### PR DESCRIPTION
fix #239, #240 

Fixed to not include packages that do not need to be bundled.