### PR TITLE
Update componentDidUpdate to prevent unnecessary re-renders

### DIFF
--- a/lib/datetime-picker.jsx
+++ b/lib/datetime-picker.jsx
@@ -67,7 +67,9 @@ export class DateTimePicker extends Component {
       const key = optionsKeys[index]
       let value = options[key]
 
-      if (value !== prevOptions[key]) {
+      // Using toString() because a regular !== does not work and causes the 
+      // component to re-render even when the properties have not been changed
+      if (value.toString() !== prevOptions[key].toString()) {
         // Hook handlers must be set as an array
         if (hooks.indexOf(key) !== -1 && !Array.isArray(value)) {
           value = [value]


### PR DESCRIPTION
I found that the component was re-rendering on every call even when no options had been changed. The !== comparison was always returning true. The bug is evident when using a 2 month layout and selecting the right hand month, this causes the component to update and move the selected month to the left hand side.